### PR TITLE
Fixed the first word of the step name in android.yml to be capitalized.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
           java-version: 11


### PR DESCRIPTION
### 🎯 Goal

I made the correction because only the step name to be changed began with a lowercase letter, while the other step names began with an uppercase letter.

### 🛠 Implementation details

I changed it from `set up JDK` to `Set up JDK`.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.