### PR TITLE
Correct the indentation width

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -38,8 +38,8 @@ gradlePlugin {
             implementationClass = "AndroidFeatureConventionPlugin"
         }
         register("androidHilt") {
-          id = "skydoves.android.hilt"
-          implementationClass = "AndroidHiltConventionPlugin"
+            id = "skydoves.android.hilt"
+            implementationClass = "AndroidHiltConventionPlugin"
         }
         register("spotless") {
             id = "skydoves.spotless"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -37,10 +37,10 @@ gradlePlugin {
             id = "skydoves.android.feature"
             implementationClass = "AndroidFeatureConventionPlugin"
         }
-      register("androidHilt") {
-        id = "skydoves.android.hilt"
-        implementationClass = "AndroidHiltConventionPlugin"
-      }
+        register("androidHilt") {
+          id = "skydoves.android.hilt"
+          implementationClass = "AndroidHiltConventionPlugin"
+        }
         register("spotless") {
             id = "skydoves.spotless"
             implementationClass = "SpotlessConventionPlugin"


### PR DESCRIPTION
### 🎯 Goal
The indentation width was out of alignment and has been corrected.

### 🛠 Implementation details
The indent width of the register("androidHilt") block was different from other blocks, so I unified the indent width to the same width as other blocks.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.