### PR TITLE
Bump Stream SDK to 5.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-streamChatSDK = "5.12.0"
+streamChatSDK = "5.13.0"
 streamLog = "1.1.3"
 balloon = "1.5.2"
 landscapist = "2.1.5"


### PR DESCRIPTION
### 🎯 Goal
Bump Stream SDK to 5.13.0.