### PR TITLE
Refactor SmallTopBar to TopAppBar

### DIFF
--- a/core-designsystem/src/main/kotlin/com/skydoves/chatgpt/core/designsystem/component/ChatGPTSmallTopBar.kt
+++ b/core-designsystem/src/main/kotlin/com/skydoves/chatgpt/core/designsystem/component/ChatGPTSmallTopBar.kt
@@ -17,10 +17,7 @@
 package com.skydoves.chatgpt.core.designsystem.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SmallTopAppBar
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,7 +25,7 @@ import com.skydoves.chatgpt.core.designsystem.theme.ChatGPTComposeTheme
 
 @Composable
 fun ChatGPTSmallTopBar(title: String) {
-  SmallTopAppBar(
+  TopAppBar(
     modifier = Modifier.fillMaxWidth(),
     title = {
       Text(


### PR DESCRIPTION
### 🎯 Goal
It is aimed to update the deprecated SmallTopAppBar to TopAppBar.

### 🛠 Implementation details
TopAppBar widget used instead of SmallTopAppBar widget

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.