### PR TITLE
Remove redundant default config line and unused imports

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -14,7 +14,6 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
       extensions.configure<BaseAppModuleExtension> {
         configureKotlinAndroid(this)
-        defaultConfig.targetSdk = 32
       }
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -2,10 +2,7 @@ import com.android.build.gradle.LibraryExtension
 import com.skydoves.chatgpt.configureKotlinAndroid
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
   override fun apply(target: Project) {

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -17,7 +17,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         configureKotlinAndroid(this)
-        defaultConfig.targetSdk = 32
       }
     }
   }


### PR DESCRIPTION
### 🎯 Goal
Removing redundant Codes from Configuration and build-logic Setup

### 🛠 Implementation details
1. Remove defaultConfig.targetrSdk line defined in Android ApplicationConventionPlugin and AndroidLibrary ConventionPlugin
2. Remove unused imports from AndroidLibraryConventionPlugin

### ✍️ Explain examples
Nothing

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.